### PR TITLE
Improve interaction with auto_bounds

### DIFF
--- a/crates/egui/src/widgets/plot/mod.rs
+++ b/crates/egui/src/widgets/plot/mod.rs
@@ -779,9 +779,6 @@ impl Plot {
                     bounds.translate(delta);
                     bounds_modified = true.into();
                 }
-                BoundsModification::Auto => {
-                    bounds_modified = false.into();
-                }
             }
         }
 
@@ -993,7 +990,6 @@ impl Plot {
 }
 
 enum BoundsModification {
-    Auto,
     Set(PlotBounds),
     Translate(Vec2),
 }
@@ -1027,12 +1023,6 @@ impl PlotUi {
     /// not change until the plot is drawn.
     pub fn plot_bounds(&self) -> PlotBounds {
         *self.last_screen_transform.bounds()
-    }
-
-    /// Set plot bounds automatically based on plot contents. Continue to do so until plot bounds are set
-    /// otherwise (manually, or by panning/zooming).
-    pub fn set_bounds_auto(&mut self) {
-        self.bounds_modifications.push(BoundsModification::Auto);
     }
 
     /// Set the plot bounds. Can be useful for implementing alternative plot navigation methods.


### PR DESCRIPTION
This PR makes some improvements to the interactions with auto bounds. I couldn't find a way to get the behavior I wanted - linked charts, auto bounds as new data comes in, but still allowing user interaction to override the auto bounds until reset.

With this PR, if you set `auto_bounds_x` or `auto_bounds_y`, then you can still use linked axes and not need to call `ui.set_auto_bounds()`, which seems to override user interaction. Since the axes are linked, it makes sense to track whether the bounds have been user-modified in a linked fashion as well.

I also removed the `set_bounds_auto` method as I don't think it's still necessary.

Thanks for the linked axes improvements!